### PR TITLE
Update data/person: change middle_name to middle_initial

### DIFF
--- a/data/person/01K5S6MAZ4YBST5GDJV827A0HH.toml
+++ b/data/person/01K5S6MAZ4YBST5GDJV827A0HH.toml
@@ -2,7 +2,7 @@ id = "01K5S6MAZ4YBST5GDJV827A0HH"
 senate_website_keys = [ "ABENI",]
 name_suffix = "III"
 last_name = "Aquino"
-middle_name = "S"
+middle_initial = "S"
 first_name = "Benigno"
 
 [[memberships]]

--- a/data/person/01K5S6MAZ4YBST5GDJV827A0HJ.toml
+++ b/data/person/01K5S6MAZ4YBST5GDJV827A0HJ.toml
@@ -1,7 +1,7 @@
 id = "01K5S6MAZ4YBST5GDJV827A0HJ"
 senate_website_keys = [ "AEDGA",]
 last_name = "Angara"
-middle_name = "J"
+middle_initial = "J"
 first_name = "Edgardo"
 
 [[memberships]]

--- a/data/person/01K5S6MAZ4YBST5GDJV827A0HK.toml
+++ b/data/person/01K5S6MAZ4YBST5GDJV827A0HK.toml
@@ -1,7 +1,7 @@
 id = "01K5S6MAZ4YBST5GDJV827A0HK"
 senate_website_keys = [ "AJOKE",]
 last_name = "Arroyo"
-middle_name = "P"
+middle_initial = "P"
 first_name = "Joker"
 
 [[memberships]]

--- a/data/person/01K5S6MAZ4YBST5GDJV827A0HN.toml
+++ b/data/person/01K5S6MAZ4YBST5GDJV827A0HN.toml
@@ -2,7 +2,7 @@ id = "01K5S6MAZ4YBST5GDJV827A0HN"
 senate_website_keys = [ "ASONN",]
 aliases = [ "Sonny",]
 last_name = "Angara"
-middle_name = "M"
+middle_initial = "M"
 first_name = "Juan Edgardo"
 
 [[memberships]]

--- a/data/person/01K5S6MAZ4YBST5GDJV827A0HQ.toml
+++ b/data/person/01K5S6MAZ4YBST5GDJV827A0HQ.toml
@@ -1,7 +1,7 @@
 id = "01K5S6MAZ4YBST5GDJV827A0HQ"
 senate_website_keys = [ "BMARI",]
 last_name = "Binay"
-middle_name = "S"
+middle_initial = "S"
 first_name = "Maria Lourdes Nancy"
 
 [[memberships]]

--- a/data/person/01K5S6MAZ4YBST5GDJV827A0HR.toml
+++ b/data/person/01K5S6MAZ4YBST5GDJV827A0HR.toml
@@ -1,7 +1,7 @@
 id = "01K5S6MAZ4YBST5GDJV827A0HR"
 senate_website_keys = [ "BRODO",]
 last_name = "Biazon"
-middle_name = "G"
+middle_initial = "G"
 first_name = "Rodolfo"
 
 [[memberships]]

--- a/data/person/01K5S6MAZ4YBST5GDJV827A0HS.toml
+++ b/data/person/01K5S6MAZ4YBST5GDJV827A0HS.toml
@@ -2,7 +2,7 @@ id = "01K5S6MAZ4YBST5GDJV827A0HS"
 senate_website_keys = [ "CALAN",]
 aliases = [ "Companero",]
 last_name = "Cayetano"
-middle_name = "S"
+middle_initial = "S"
 first_name = "Alan Peter"
 
 [[memberships]]

--- a/data/person/01K5S6MAZ4YBST5GDJV827A0HT.toml
+++ b/data/person/01K5S6MAZ4YBST5GDJV827A0HT.toml
@@ -1,7 +1,7 @@
 id = "01K5S6MAZ4YBST5GDJV827A0HT"
 senate_website_keys = [ "CPIAS",]
 last_name = "Cayetano"
-middle_name = "S"
+middle_initial = "S"
 first_name = "Companera Pia"
 
 [[memberships]]

--- a/data/person/01K5S6MAZ4YBST5GDJV827A0HV.toml
+++ b/data/person/01K5S6MAZ4YBST5GDJV827A0HV.toml
@@ -1,7 +1,7 @@
 id = "01K5S6MAZ4YBST5GDJV827A0HV"
 senate_website_keys = [ "DFRAN",]
 last_name = "Drilon"
-middle_name = "M"
+middle_initial = "M"
 first_name = "Franklin"
 
 [[memberships]]

--- a/data/person/01K5S6MAZ4YBST5GDJV827A0HW.toml
+++ b/data/person/01K5S6MAZ4YBST5GDJV827A0HW.toml
@@ -1,7 +1,7 @@
 id = "01K5S6MAZ4YBST5GDJV827A0HW"
 senate_website_keys = [ "DLEIL",]
 last_name = "De Lima"
-middle_name = "M"
+middle_initial = "M"
 first_name = "Leila"
 
 [[memberships]]

--- a/data/person/01K5S6MAZ4YBST5GDJV827A0HY.toml
+++ b/data/person/01K5S6MAZ4YBST5GDJV827A0HY.toml
@@ -2,7 +2,7 @@ id = "01K5S6MAZ4YBST5GDJV827A0HY"
 senate_website_keys = [ "EFRAN",]
 aliases = [ "Chiz",]
 last_name = "Escudero"
-middle_name = "G"
+middle_initial = "G"
 first_name = "Francis"
 
 [[memberships]]

--- a/data/person/01K5S6MAZ4YBST5GDJV827A0HZ.toml
+++ b/data/person/01K5S6MAZ4YBST5GDJV827A0HZ.toml
@@ -1,7 +1,7 @@
 id = "01K5S6MAZ4YBST5GDJV827A0HZ"
 senate_website_keys = [ "EJING",]
 last_name = "Ejercito-Estrada"
-middle_name = "P"
+middle_initial = "P"
 first_name = "Jinggoy"
 
 [[memberships]]

--- a/data/person/01K5S6MAZ4YBST5GDJV827A0J0.toml
+++ b/data/person/01K5S6MAZ4YBST5GDJV827A0J0.toml
@@ -1,7 +1,7 @@
 id = "01K5S6MAZ4YBST5GDJV827A0J0"
 senate_website_keys = [ "EJOSE", "EVICT",]
 last_name = "Ejercito"
-middle_name = "G"
+middle_initial = "G"
 first_name = "Joseph Victor"
 
 [[memberships]]

--- a/data/person/01K5S6MAZ4YBST5GDJV827A0J2.toml
+++ b/data/person/01K5S6MAZ4YBST5GDJV827A0J2.toml
@@ -2,7 +2,7 @@ id = "01K5S6MAZ4YBST5GDJV827A0J2"
 senate_website_keys = [ "ELUIS",]
 aliases = [ "Loi",]
 last_name = "Ejercito Estrada"
-middle_name = "P"
+middle_initial = "P"
 first_name = "Luisa"
 
 [[memberships]]

--- a/data/person/01K5S6MAZ4YBST5GDJV827A0J3.toml
+++ b/data/person/01K5S6MAZ4YBST5GDJV827A0J3.toml
@@ -1,7 +1,7 @@
 id = "01K5S6MAZ4YBST5GDJV827A0J3"
 senate_website_keys = [ "FJUAN",]
 last_name = "Flavier"
-middle_name = "M"
+middle_initial = "M"
 first_name = "Juan"
 
 [[memberships]]

--- a/data/person/01K5S6MAZ4YBST5GDJV827A0J4.toml
+++ b/data/person/01K5S6MAZ4YBST5GDJV827A0J4.toml
@@ -1,7 +1,7 @@
 id = "01K5S6MAZ4YBST5GDJV827A0J4"
 senate_website_keys = [ "GCHRI",]
 last_name = "Go"
-middle_name = "T"
+middle_initial = "T"
 first_name = "Christopher Lawrence"
 
 [[memberships]]

--- a/data/person/01K5S6MAZ4YBST5GDJV827A0J5.toml
+++ b/data/person/01K5S6MAZ4YBST5GDJV827A0J5.toml
@@ -2,7 +2,7 @@ id = "01K5S6MAZ4YBST5GDJV827A0J5"
 senate_website_keys = [ "GRICH",]
 aliases = [ "Dick",]
 last_name = "Gordon"
-middle_name = "J"
+middle_initial = "J"
 first_name = "Richard"
 
 [[memberships]]

--- a/data/person/01K5S6MAZ4YBST5GDJV827A0J6.toml
+++ b/data/person/01K5S6MAZ4YBST5GDJV827A0J6.toml
@@ -1,7 +1,7 @@
 id = "01K5S6MAZ4YBST5GDJV827A0J6"
 senate_website_keys = [ "GSHER",]
 last_name = "Gatchalian"
-middle_name = "T"
+middle_initial = "T"
 first_name = "Sherwin"
 
 [[memberships]]

--- a/data/person/01K5S6MAZ4YBST5GDJV827A0J9.toml
+++ b/data/person/01K5S6MAZ4YBST5GDJV827A0J9.toml
@@ -2,7 +2,7 @@ id = "01K5S6MAZ4YBST5GDJV827A0J9"
 senate_website_keys = [ "HGREG",]
 name_suffix = "II"
 last_name = "Honasan"
-middle_name = "B"
+middle_initial = "B"
 first_name = "Gregorio"
 
 [[memberships]]

--- a/data/person/01K5S6MAZ4YBST5GDJV827A0JB.toml
+++ b/data/person/01K5S6MAZ4YBST5GDJV827A0JB.toml
@@ -1,7 +1,7 @@
 id = "01K5S6MAZ4YBST5GDJV827A0JB"
 senate_website_keys = [ "LALFR",]
 last_name = "Lim"
-middle_name = "S"
+middle_initial = "S"
 first_name = "Alfredo"
 
 [[memberships]]

--- a/data/person/01K5S6MAZ4YBST5GDJV827A0JC.toml
+++ b/data/person/01K5S6MAZ4YBST5GDJV827A0JC.toml
@@ -1,7 +1,7 @@
 id = "01K5S6MAZ4YBST5GDJV827A0JC"
 senate_website_keys = [ "LLORE",]
 last_name = "Legarda"
-middle_name = "B"
+middle_initial = "B"
 first_name = "Loren"
 
 [[memberships]]

--- a/data/person/01K5S6MAZ4YBST5GDJV827A0JD.toml
+++ b/data/person/01K5S6MAZ4YBST5GDJV827A0JD.toml
@@ -2,7 +2,7 @@ id = "01K5S6MAZ4YBST5GDJV827A0JD"
 senate_website_keys = [ "LMANU",]
 aliases = [ "Lito",]
 last_name = "Lapid"
-middle_name = "M"
+middle_initial = "M"
 first_name = "Manuel"
 
 [[memberships]]

--- a/data/person/01K5S6MAZ4YBST5GDJV827A0JE.toml
+++ b/data/person/01K5S6MAZ4YBST5GDJV827A0JE.toml
@@ -1,7 +1,7 @@
 id = "01K5S6MAZ4YBST5GDJV827A0JE"
 senate_website_keys = [ "LPANF",]
 last_name = "Lacson"
-middle_name = "M"
+middle_initial = "M"
 first_name = "Panfilo"
 
 [[memberships]]

--- a/data/person/01K5S6MAZ4YBST5GDJV827A0JF.toml
+++ b/data/person/01K5S6MAZ4YBST5GDJV827A0JF.toml
@@ -2,7 +2,7 @@ id = "01K5S6MAZ4YBST5GDJV827A0JF"
 senate_website_keys = [ "MFERD",]
 aliases = [ "Bongbong",]
 last_name = "Marcos"
-middle_name = "R"
+middle_initial = "R"
 first_name = "Ferdinand"
 
 [[memberships]]

--- a/data/person/01K5S6MAZ4YBST5GDJV827A0JG.toml
+++ b/data/person/01K5S6MAZ4YBST5GDJV827A0JG.toml
@@ -1,7 +1,7 @@
 id = "01K5S6MAZ4YBST5GDJV827A0JG"
 senate_website_keys = [ "MIMEE",]
 last_name = "Marcos"
-middle_name = "R"
+middle_initial = "R"
 first_name = "Imee"
 
 [[memberships]]

--- a/data/person/01K5S6MAZ4YBST5GDJV827A0JJ.toml
+++ b/data/person/01K5S6MAZ4YBST5GDJV827A0JJ.toml
@@ -2,7 +2,7 @@ id = "01K5S6MAZ4YBST5GDJV827A0JJ"
 senate_website_keys = [ "MRAMO",]
 name_suffix = "Jr"
 last_name = "Magsaysay"
-middle_name = "B"
+middle_initial = "B"
 first_name = "Ramon"
 
 [[memberships]]

--- a/data/person/01K5S6MAZ4YBST5GDJV827A0JK.toml
+++ b/data/person/01K5S6MAZ4YBST5GDJV827A0JK.toml
@@ -1,7 +1,7 @@
 id = "01K5S6MAZ4YBST5GDJV827A0JK"
 senate_website_keys = [ "MRODA",]
 last_name = "Marcoleta"
-middle_name = "D"
+middle_initial = "D"
 first_name = "Rodante"
 
 [[memberships]]

--- a/data/person/01K5S6MAZ4YBST5GDJV827A0JM.toml
+++ b/data/person/01K5S6MAZ4YBST5GDJV827A0JM.toml
@@ -2,7 +2,7 @@ id = "01K5S6MAZ4YBST5GDJV827A0JM"
 senate_website_keys = [ "OSERG",]
 name_suffix = "III"
 last_name = "Osmena"
-middle_name = "R"
+middle_initial = "R"
 first_name = "Sergio"
 
 [[memberships]]

--- a/data/person/01K5S6MAZ4YBST5GDJV827A0JN.toml
+++ b/data/person/01K5S6MAZ4YBST5GDJV827A0JN.toml
@@ -2,7 +2,7 @@ id = "01K5S6MAZ4YBST5GDJV827A0JN"
 senate_website_keys = [ "PAQUI",]
 name_suffix = "Jr"
 last_name = "Pimentel"
-middle_name = "Q"
+middle_initial = "Q"
 first_name = "Aquilino"
 
 [[memberships]]

--- a/data/person/01K5S6MAZ4YBST5GDJV827A0JP.toml
+++ b/data/person/01K5S6MAZ4YBST5GDJV827A0JP.toml
@@ -2,7 +2,7 @@ id = "01K5S6MAZ4YBST5GDJV827A0JP"
 senate_website_keys = [ "PEMMA",]
 aliases = [ "Manny",]
 last_name = "Pacquiao"
-middle_name = "D"
+middle_initial = "D"
 first_name = "Emmanuel"
 
 [[memberships]]

--- a/data/person/01K5S6MAZ4YBST5GDJV827A0JQ.toml
+++ b/data/person/01K5S6MAZ4YBST5GDJV827A0JQ.toml
@@ -1,7 +1,7 @@
 id = "01K5S6MAZ4YBST5GDJV827A0JQ"
 senate_website_keys = [ "PFRAN",]
 last_name = "Pangilinan"
-middle_name = "N"
+middle_initial = "N"
 first_name = "Francis"
 
 [[memberships]]

--- a/data/person/01K5S6MAZ4YBST5GDJV827A0JR.toml
+++ b/data/person/01K5S6MAZ4YBST5GDJV827A0JR.toml
@@ -1,7 +1,7 @@
 id = "01K5S6MAZ4YBST5GDJV827A0JR"
 senate_website_keys = [ "PGRAC",]
 last_name = "Poe"
-middle_name = "L"
+middle_initial = "L"
 first_name = "Grace"
 
 [[memberships]]

--- a/data/person/01K5S6MAZ4YBST5GDJV827A0JS.toml
+++ b/data/person/01K5S6MAZ4YBST5GDJV827A0JS.toml
@@ -1,7 +1,7 @@
 id = "01K5S6MAZ4YBST5GDJV827A0JS"
 senate_website_keys = [ "PROBI",]
 last_name = "Padilla"
-middle_name = "C"
+middle_initial = "C"
 first_name = "Robinhood"
 
 [[memberships]]

--- a/data/person/01K5S6MAZ4YBST5GDJV827A0JV.toml
+++ b/data/person/01K5S6MAZ4YBST5GDJV827A0JV.toml
@@ -1,7 +1,7 @@
 id = "01K5S6MAZ4YBST5GDJV827A0JV"
 senate_website_keys = [ "RRALP",]
 last_name = "Recto"
-middle_name = "G"
+middle_initial = "G"
 first_name = "Ralph"
 
 [[memberships]]

--- a/data/person/01K5S6MAZ4YBST5GDJV827A0JW.toml
+++ b/data/person/01K5S6MAZ4YBST5GDJV827A0JW.toml
@@ -2,7 +2,7 @@ id = "01K5S6MAZ4YBST5GDJV827A0JW"
 senate_website_keys = [ "RRAMO",]
 name_suffix = "Jr"
 last_name = "Revilla"
-middle_name = "A"
+middle_initial = "A"
 first_name = "Ramon"
 
 [[memberships]]

--- a/data/person/01K5S6MAZ4YBST5GDJV827A0JY.toml
+++ b/data/person/01K5S6MAZ4YBST5GDJV827A0JY.toml
@@ -2,7 +2,7 @@ id = "01K5S6MAZ4YBST5GDJV827A0JY"
 senate_website_keys = [ "SVICE",]
 name_suffix = "III"
 last_name = "Sotto"
-middle_name = "C"
+middle_initial = "C"
 first_name = "Vicente"
 
 [[memberships]]

--- a/data/person/01K5S6MAZ4YBST5GDJV827A0JZ.toml
+++ b/data/person/01K5S6MAZ4YBST5GDJV827A0JZ.toml
@@ -3,7 +3,7 @@ senate_website_keys = [ "TANTO",]
 aliases = [ "Sonny",]
 name_suffix = "IV"
 last_name = "Trillanes"
-middle_name = "F"
+middle_initial = "F"
 first_name = "Antonio"
 
 [[memberships]]

--- a/data/person/01K5S6MAZ4YBST5GDJV827A0K0.toml
+++ b/data/person/01K5S6MAZ4YBST5GDJV827A0K0.toml
@@ -1,7 +1,7 @@
 id = "01K5S6MAZ4YBST5GDJV827A0K0"
 senate_website_keys = [ "TERWI",]
 last_name = "Tulfo"
-middle_name = "T"
+middle_initial = "T"
 first_name = "Erwin"
 
 [[memberships]]

--- a/data/person/01K5S6MAZ4YBST5GDJV827A0K1.toml
+++ b/data/person/01K5S6MAZ4YBST5GDJV827A0K1.toml
@@ -1,16 +1,16 @@
-id = "01K5S6MAZ4YBST5GDJV827A0K1"
-senate_website_keys = [ "TFRAN",]
-aliases = [ "Tol",]
-last_name = "Tolentino"
-middle_name = "N"
-first_name = "Francis"
+id = "01K5S6MAZ4YBST5GDJV827A0JP"
+senate_website_keys = [ "PEMMA",]
+aliases = [ "Manny",]
+last_name = "Pacquiao"
+middle_initial = "D"
+first_name = "Emmanuel"
 
 [[memberships]]
 type = "congress"
-congress = 18
+congress = 17
 position = "senator"
 
 [[memberships]]
 type = "congress"
-congress = 19
+congress = 18
 position = "senator"

--- a/data/person/01K5S6MAZ4YBST5GDJV827A0K2.toml
+++ b/data/person/01K5S6MAZ4YBST5GDJV827A0K2.toml
@@ -1,12 +1,32 @@
-id = "01K5S6MAZ4YBST5GDJV827A0K2"
-senate_website_keys = [ "TRAFF",]
-last_name = "Tulfo"
-middle_name = "T"
-first_name = "Raffy"
+id = "01K5S6MAZ4YBST5GDJV827A0JQ"
+senate_website_keys = [ "PFRAN",]
+last_name = "Pangilinan"
+middle_initial = "N"
+first_name = "Francis"
 
 [[memberships]]
 type = "congress"
-congress = 19
+congress = 13
+position = "senator"
+
+[[memberships]]
+type = "congress"
+congress = 14
+position = "senator"
+
+[[memberships]]
+type = "congress"
+congress = 15
+position = "senator"
+
+[[memberships]]
+type = "congress"
+congress = 17
+position = "senator"
+
+[[memberships]]
+type = "congress"
+congress = 18
 position = "senator"
 
 [[memberships]]

--- a/data/person/01K5S6MAZ4YBST5GDJV827A0K3.toml
+++ b/data/person/01K5S6MAZ4YBST5GDJV827A0K3.toml
@@ -1,10 +1,25 @@
-id = "01K5S6MAZ4YBST5GDJV827A0K3"
-senate_website_keys = [ "VCAMI",]
-last_name = "Villar"
-middle_name = "A"
-first_name = "Camille"
+id = "01K5S6MAZ4YBST5GDJV827A0JR"
+senate_website_keys = [ "PGRAC",]
+last_name = "Poe"
+middle_initial = "L"
+first_name = "Grace"
 
 [[memberships]]
 type = "congress"
-congress = 20
+congress = 16
+position = "senator"
+
+[[memberships]]
+type = "congress"
+congress = 17
+position = "senator"
+
+[[memberships]]
+type = "congress"
+congress = 18
+position = "senator"
+
+[[memberships]]
+type = "congress"
+congress = 19
 position = "senator"

--- a/data/person/01K5S6MAZ4YBST5GDJV827A0K4.toml
+++ b/data/person/01K5S6MAZ4YBST5GDJV827A0K4.toml
@@ -1,25 +1,15 @@
-id = "01K5S6MAZ4YBST5GDJV827A0K4"
-senate_website_keys = [ "VCYNT",]
-last_name = "Villar"
-middle_name = "A"
-first_name = "Cynthia"
-
-[[memberships]]
-type = "congress"
-congress = 16
-position = "senator"
-
-[[memberships]]
-type = "congress"
-congress = 17
-position = "senator"
-
-[[memberships]]
-type = "congress"
-congress = 18
-position = "senator"
+id = "01K5S6MAZ4YBST5GDJV827A0JS"
+senate_website_keys = [ "PROBI",]
+last_name = "Padilla"
+middle_initial = "C"
+first_name = "Robinhood"
 
 [[memberships]]
 type = "congress"
 congress = 19
+position = "senator"
+
+[[memberships]]
+type = "congress"
+congress = 20
 position = "senator"

--- a/data/person/01K5S6MAZ4YBST5GDJV827A0K6.toml
+++ b/data/person/01K5S6MAZ4YBST5GDJV827A0K6.toml
@@ -1,7 +1,7 @@
 id = "01K5S6MAZ4YBST5GDJV827A0K6"
 senate_website_keys = [ "VMANN",]
 last_name = "Villar"
-middle_name = "B"
+middle_initial = "B"
 first_name = "Manny"
 
 [[memberships]]

--- a/data/person/01K5S6MAZ4YBST5GDJV827A0K7.toml
+++ b/data/person/01K5S6MAZ4YBST5GDJV827A0K7.toml
@@ -1,9 +1,8 @@
-id = "01K5S6MAZ4YBST5GDJV827A0K7"
-senate_website_keys = [ "VMANU",]
-name_suffix = "Jr"
-last_name = "Villar"
-middle_name = "B"
-first_name = "Manuel"
+id = "01K5S6MAZ4YBST5GDJV827A0JV"
+senate_website_keys = [ "RRALP",]
+last_name = "Recto"
+middle_initial = "G"
+first_name = "Ralph"
 
 [[memberships]]
 type = "congress"
@@ -12,5 +11,20 @@ position = "senator"
 
 [[memberships]]
 type = "congress"
-congress = 14
+congress = 15
+position = "senator"
+
+[[memberships]]
+type = "congress"
+congress = 16
+position = "senator"
+
+[[memberships]]
+type = "congress"
+congress = 17
+position = "senator"
+
+[[memberships]]
+type = "congress"
+congress = 18
 position = "senator"

--- a/data/person/01K5S6MAZ4YBST5GDJV827A0K8.toml
+++ b/data/person/01K5S6MAZ4YBST5GDJV827A0K8.toml
@@ -1,15 +1,36 @@
-id = "01K5S6MAZ4YBST5GDJV827A0K8"
-senate_website_keys = [ "VMARK",]
-last_name = "Villar"
-middle_name = "A"
-first_name = "Mark"
+id = "01K5S6MAZ4YBST5GDJV827A0JW"
+senate_website_keys = [ "RRAMO",]
+name_suffix = "Jr"
+last_name = "Revilla"
+middle_initial = "A"
+first_name = "Ramon"
 
 [[memberships]]
 type = "congress"
-congress = 19
+congress = 13
 position = "senator"
 
 [[memberships]]
 type = "congress"
-congress = 20
+congress = 14
+position = "senator"
+
+[[memberships]]
+type = "congress"
+congress = 15
+position = "senator"
+
+[[memberships]]
+type = "congress"
+congress = 16
+position = "senator"
+
+[[memberships]]
+type = "congress"
+congress = 18
+position = "senator"
+
+[[memberships]]
+type = "congress"
+congress = 19
 position = "senator"

--- a/data/person/01K5S6MAZ4YBST5GDJV827A0K9.toml
+++ b/data/person/01K5S6MAZ4YBST5GDJV827A0K9.toml
@@ -1,7 +1,7 @@
 id = "01K5S6MAZ4YBST5GDJV827A0K9"
 senate_website_keys = [ "ZJMIG", "ZMIGU",]
 last_name = "Zubiri"
-middle_name = "F"
+middle_initial = "F"
 first_name = "Juan Miguel"
 
 [[memberships]]

--- a/data/person/01K5ST3ZMCESN2JQBJV2NJ3AVQ.toml
+++ b/data/person/01K5ST3ZMCESN2JQBJV2NJ3AVQ.toml
@@ -3,7 +3,7 @@ congress_website_primary_keys = [ 536,]
 congress_website_author_keys = [ "E001",]
 last_name = "Abad"
 first_name = "Henedina"
-middle_name = "R"
+middle_initial = "R"
 aliases = [ "Dina",]
 
 [[memberships]]

--- a/data/person/01K5ST3ZMGJ7J2QZSP8D03NQ2Z.toml
+++ b/data/person/01K5ST3ZMGJ7J2QZSP8D03NQ2Z.toml
@@ -3,7 +3,7 @@ congress_website_primary_keys = [ 537,]
 congress_website_author_keys = [ "E002",]
 last_name = "Abalos"
 first_name = "Benjamin"
-middle_name = "D"
+middle_initial = "D"
 aliases = [ "Benhur",]
 name_suffix = "Jr"
 

--- a/data/person/01K5ST3ZMKVXZKBCWK4MKFBZFN.toml
+++ b/data/person/01K5ST3ZMKVXZKBCWK4MKFBZFN.toml
@@ -3,7 +3,7 @@ congress_website_primary_keys = [ 2,]
 congress_website_author_keys = [ "K106",]
 last_name = "Abalos"
 first_name = "Jc"
-middle_name = "M"
+middle_initial = "M"
 
 [[memberships]]
 type = "congress"

--- a/data/person/01K5ST3ZNFVW05HFRGTF1YP6AQ.toml
+++ b/data/person/01K5ST3ZNFVW05HFRGTF1YP6AQ.toml
@@ -3,7 +3,7 @@ congress_website_primary_keys = [ 3,]
 congress_website_author_keys = [ "E003",]
 last_name = "Abante"
 first_name = "Bienvenido"
-middle_name = "M"
+middle_initial = "M"
 name_suffix = "Jr"
 
 [[memberships]]

--- a/data/person/01K5ST3ZPVEJZ2G8RTR9G6S8MF.toml
+++ b/data/person/01K5ST3ZPVEJZ2G8RTR9G6S8MF.toml
@@ -3,7 +3,7 @@ congress_website_primary_keys = [ 804,]
 congress_website_author_keys = [ "H001",]
 last_name = "Abaya"
 first_name = "Francis"
-middle_name = "Gerald A"
+middle_initial = "Gerald A"
 
 [[memberships]]
 type = "congress"


### PR DESCRIPTION
### Summary
This PR resolves the data field naming inconsistency reported in issue #1  by updating all instances of `middle_name` to `middle_initial` in Senate data files within the `data/people/` directory.
